### PR TITLE
fix: Update projects in the store as they are pulled from Gitlab

### DIFF
--- a/pkg/controller/projects.go
+++ b/pkg/controller/projects.go
@@ -44,7 +44,6 @@ func (c *Controller) PullProject(ctx context.Context, project config.Project) er
 				WithError(err).
 				Error()
 		}
-
 	}
 
 	return nil

--- a/pkg/controller/projects.go
+++ b/pkg/controller/projects.go
@@ -34,6 +34,17 @@ func (c *Controller) PullProject(ctx context.Context, project config.Project) er
 
 		c.ScheduleTask(ctx, schemas.TaskTypePullRefsFromProject, string(gp.Key()), gp)
 		c.ScheduleTask(ctx, schemas.TaskTypePullEnvironmentsFromProject, string(gp.Key()), gp)
+	} else {
+		log.WithFields(log.Fields{
+			"project-name": gp.Name,
+		}).Info("updating project")
+
+		if err := c.Store.SetProject(ctx, gp); err != nil {
+			log.WithContext(ctx).
+				WithError(err).
+				Error()
+		}
+
 	}
 
 	return nil
@@ -70,6 +81,21 @@ func (c *Controller) PullProjectsFromWildcard(ctx context.Context, w config.Wild
 
 			c.ScheduleTask(ctx, schemas.TaskTypePullRefsFromProject, string(p.Key()), p)
 			c.ScheduleTask(ctx, schemas.TaskTypePullEnvironmentsFromProject, string(p.Key()), p)
+		} else {
+			log.WithFields(log.Fields{
+				"wildcard-search":                  w.Search,
+				"wildcard-owner-kind":              w.Owner.Kind,
+				"wildcard-owner-name":              w.Owner.Name,
+				"wildcard-owner-include-subgroups": w.Owner.IncludeSubgroups,
+				"wildcard-archived":                w.Archived,
+				"project-name":                     p.Name,
+			}).Info("updating project")
+
+			if err := c.Store.SetProject(ctx, p); err != nil {
+				log.WithContext(ctx).
+					WithError(err).
+					Error()
+			}
 		}
 	}
 

--- a/pkg/controller/projects_test.go
+++ b/pkg/controller/projects_test.go
@@ -15,19 +15,66 @@ func TestPullProjectsFromWildcard(t *testing.T) {
 	ctx, c, mux, srv := newTestController(config.Config{})
 	defer srv.Close()
 
+	topicsIdentifier := 0
+
 	mux.HandleFunc("/api/v4/projects",
 		func(w http.ResponseWriter, r *http.Request) {
-			fmt.Fprint(w, `[{"id":2,"path_with_namespace":"bar","jobs_enabled":true}]`)
+			fmt.Fprintf(w, `[{"id":2,"path_with_namespace":"bar","jobs_enabled":true,"topics":["foo%d","bar%d"]}]`, topicsIdentifier, topicsIdentifier)
+			topicsIdentifier += 1
 		})
 
 	w := config.NewWildcard()
 	assert.NoError(t, c.PullProjectsFromWildcard(ctx, w))
 
 	projects, _ := c.Store.Projects(ctx)
-	p1 := schemas.NewProject("bar", []string{})
+	p1 := schemas.NewProject("bar", []string{"foo0", "bar0"})
+	p2 := schemas.NewProject("bar", []string{"foo1", "bar1"})
 
 	expectedProjects := schemas.Projects{
 		p1.Key(): p1,
 	}
 	assert.Equal(t, expectedProjects, projects)
+
+	expectedUpdatedProjects := schemas.Projects{
+		p2.Key(): p2,
+	}
+
+	// Pull projects again, which will have topics updated
+	assert.NoError(t, c.PullProjectsFromWildcard(ctx, w))
+	projects, _ = c.Store.Projects(ctx)
+	assert.Equal(t, expectedUpdatedProjects, projects)
+}
+
+func TestPullProjects(t *testing.T) {
+	ctx, c, mux, srv := newTestController(config.Config{})
+	defer srv.Close()
+
+	topicsIdentifier := 0
+
+	mux.HandleFunc(fmt.Sprintf("/api/v4/projects/%s", "foo%2Fbar"),
+		func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintf(w, `{"id":2,"path_with_namespace":"bar","jobs_enabled":true,"topics":["foo%d","bar%d"]}`, topicsIdentifier, topicsIdentifier)
+			topicsIdentifier += 1
+		})
+
+	w := config.NewProject("foo/bar")
+	assert.NoError(t, c.PullProject(ctx, w))
+
+	projects, _ := c.Store.Projects(ctx)
+	p1 := schemas.NewProject("bar", []string{"foo0", "bar0"})
+	p2 := schemas.NewProject("bar", []string{"foo1", "bar1"})
+
+	expectedProjects := schemas.Projects{
+		p1.Key(): p1,
+	}
+	assert.Equal(t, expectedProjects, projects)
+
+	expectedUpdatedProjects := schemas.Projects{
+		p2.Key(): p2,
+	}
+
+	// Pull projects again, which will have topics updated
+	assert.NoError(t, c.PullProject(ctx, w))
+	projects, _ = c.Store.Projects(ctx)
+	assert.Equal(t, expectedUpdatedProjects, projects)
 }


### PR DESCRIPTION
This PR ensures that project updates, specifically Topics, are updated from Gitlab whenever they are pulled from Gitlab REST api.